### PR TITLE
Test aarch64 support for leveldbjni jar

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,14 @@
+- project:
+    name: theopenlab/spark
+    check:
+      jobs:
+        - spark-build-and-test-x86-leveldbjni
+
+- job:
+    name: spark-build-and-test-x86-leveldbjni
+    parent: init-test
+    description: |
+      The spark build and test other modules in openlab cluster.
+    run: .zuul/playbooks/spark-build/run_all.yaml
+    nodeset: ubuntu-xenial
+    timeout: 86400

--- a/.zuul/playbooks/spark-build/run_all.yaml
+++ b/.zuul/playbooks/spark-build/run_all.yaml
@@ -1,0 +1,37 @@
+- hosts: all
+  tasks:
+    - name: Build spark master using mvn with hadoop 2.7
+      shell:
+        cmd: |
+          set -exo pipefail
+          sudo apt-get update -y
+
+          # Install java
+          sudo apt-get install default-jre -y
+          sudo apt-get install default-jdk -y
+          java_home=$(dirname $(dirname $(update-alternatives --list javac)))
+          echo "export JAVA_HOME=${java_home}" >> ~/.profile
+          echo "export PATH=${java_home}/bin:$PATH" >> ~/.profile
+          source ~/.profile
+  
+          # Install maven
+          wget http://www.us.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz
+          tar -xvf apache-maven-3.6.2-bin.tar.gz
+          export PATH=$PWD/apache-maven-3.6.2/bin:$PATH
+
+          # fix kafka authfail tests
+          sudo sed -i "s|127.0.0.1 $(hostname) localhost|127.0.0.1 localhost $(hostname)|" /etc/hosts
+
+          cd {{ ansible_user_dir }}/{{ zuul.project.src_dir }}
+
+          ./build/mvn clean package -DskipTests -Phadoop-2.7 -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos
+
+          # use leveldbjni arm supporting jar
+          # wget https://repo1.maven.org/maven2/org/openlabtesting/leveldbjni/leveldbjni-all/1.8/leveldbjni-all-1.8.jar
+          # mvn install:install-file -DgroupId=org.fusesource.leveldbjni -DartifactId=leveldbjni-all -Dversion=1.8 -Dpackaging=jar -Dfile=leveldbjni-all-1.8.jar
+
+          ./build/mvn test -Phadoop-2.7 -Pyarn -Phive -Phive-thriftserver -Pkinesis-asl -Pmesos
+
+        chdir: '/home/zuul/src'
+        executable: /bin/bash
+      environment: '{{ global_env }}'

--- a/common/kvstore/pom.xml
+++ b/common/kvstore/pom.xml
@@ -45,7 +45,7 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
+      <groupId>${leveldbjni.group}</groupId>
       <artifactId>leveldbjni-all</artifactId>
     </dependency>
     <dependency>

--- a/common/network-common/pom.xml
+++ b/common/network-common/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
+      <groupId>${leveldbjni.group}</groupId>
       <artifactId>leveldbjni-all</artifactId>
       <version>1.8</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,7 @@
     <spark.test.home>${session.executionRootDirectory}</spark.test.home>
 
     <CodeCacheSize>1g</CodeCacheSize>
+    <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
   </properties>
   <repositories>
     <repository>
@@ -526,7 +527,7 @@
         <version>${commons.httpcore.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.fusesource.leveldbjni</groupId>
+        <groupId>${leveldbjni.group}</groupId>
         <artifactId>leveldbjni-all</artifactId>
         <version>1.8</version>
       </dependency>
@@ -954,6 +955,10 @@
         <scope>${hadoop.deps.scope}</scope>
         <exclusions>
           <exclusion>
+            <groupId>org.fusesource.leveldbjni</groupId>
+            <artifactId>leveldbjni-all</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
@@ -1200,6 +1205,10 @@
         <scope>test</scope>
         <exclusions>
           <exclusion>
+            <groupId>org.fusesource.leveldbjni</groupId>
+            <artifactId>leveldbjni-all</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
@@ -1239,6 +1248,10 @@
         <version>${yarn.version}</version>
         <scope>${hadoop.deps.scope}</scope>
         <exclusions>
+          <exclusion>
+            <groupId>org.fusesource.leveldbjni</groupId>
+            <artifactId>leveldbjni-all</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
@@ -3080,6 +3093,18 @@
     </profile>
     <profile>
       <id>sparkr</id>
+    </profile>
+    <profile>
+      <id>aarch64</id>
+      <properties>
+        <leveldbjni.group>org.openlabtesting.leveldbjni</leveldbjni.group>
+      </properties>
+      <activation>
+        <os>
+          <family>linux</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This change adds a aarch64 profile to switch to use the
org.openlabtesting.leveldbjni which supports aarch64
platform.

Test on x86.
